### PR TITLE
Update Annotations.kt, fixed typo: RgpPixel -> RgbPixel (p->b)

### DIFF
--- a/core/commonMain/src/kotlinx/serialization/Annotations.kt
+++ b/core/commonMain/src/kotlinx/serialization/Annotations.kt
@@ -39,9 +39,9 @@ import kotlin.reflect.*
  *
  * @Serializable
  * class RgbExample(
- *     @Serializable(with = RgbAsHexString::class) p1: RgpPixel, // Serialize as HEX string, e.g. #FFFF00
- *     @Serializable(with = RgbAsSingleInt::class) p2: RgpPixel, // Serialize as single integer, e.g. 16711680
- *     p3: RgpPixel // Serialize as 3 short components, e.g. { "red": 255, "green": 255, "blue": 0 }
+ *     @Serializable(with = RgbAsHexString::class) p1: RgbPixel, // Serialize as HEX string, e.g. #FFFF00
+ *     @Serializable(with = RgbAsSingleInt::class) p2: RgbPixel, // Serialize as single integer, e.g. 16711680
+ *     p3: RgbPixel // Serialize as 3 short components, e.g. { "red": 255, "green": 255, "blue": 0 }
  * )
  * ```
  * In this example, each pixel will be serialized using different data representation.


### PR DESCRIPTION
It was RgpPixel but it should be RgbPixel as the class with this name was declared before: 
`class RgbPixel(val red: Short, val green: Short, val blue: Short)`